### PR TITLE
Update zlib to 1.2.12 and use stable URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ $(STATIC_LIBS)/libdeflate.a:
 	$(WGET) 'https://github.com/ebiggers/libdeflate/archive/v1.8.tar.gz' | tar -xzf - -C $(STATIC_LIBS) && \
 	cd $(STATIC_LIBS)/libdeflate-*/ && $(MAKE) libdeflate.a && cp libdeflate.a libdeflate.h ..
 $(STATIC_LIBS)/libz.a:
-	$(WGET) 'https://zlib.net/zlib-1.2.11.tar.gz' | tar -xzf - -C $(STATIC_LIBS) && \
+	$(WGET) 'https://zlib.net/fossils/zlib-1.2.12.tar.gz' | tar -xzf - -C $(STATIC_LIBS) && \
 	cd $(STATIC_LIBS)/zlib-*/ && ./configure && $(MAKE) libz.a && cp zlib.h zconf.h libz.a ..
 $(STATIC_LIBS)/libbz2.a:
 	$(WGET) 'https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz' | tar -xzf - -C $(STATIC_LIBS) && \


### PR DESCRIPTION
The make command was not working, because a new version of zlib has been released. This PR updates to the latest version of zlib, and uses a persistent URL to prevent the issue from occurring again.